### PR TITLE
fix: show flag icons in language switch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,11 +28,27 @@
       <!-- 🌍 Jazyk (SK/EN) -->
       <div class="lang-switch" role="group" aria-label="Language">
         <button type="button" class="lang-btn" data-lang="sk" id="langBtnSk" aria-label="Slovenčina">
-          <span class="lang-flag" aria-hidden="true">🇸🇰</span>
+          <img
+            class="lang-flag-img"
+            src="https://flagcdn.com/24x18/sk.png"
+            width="24"
+            height="18"
+            alt=""
+            aria-hidden="true"
+            loading="lazy"
+          />
           <span class="lang-code">SK</span>
         </button>
         <button type="button" class="lang-btn" data-lang="en" id="langBtnEn" aria-label="English">
-          <span class="lang-flag" aria-hidden="true">🇬🇧</span>
+          <img
+            class="lang-flag-img"
+            src="https://flagcdn.com/24x18/gb.png"
+            width="24"
+            height="18"
+            alt=""
+            aria-hidden="true"
+            loading="lazy"
+          />
           <span class="lang-code">EN</span>
         </button>
       </div>

--- a/public/style.css
+++ b/public/style.css
@@ -6092,6 +6092,15 @@ header{
   line-height: 1;
 }
 
+.lang-flag-img{
+  display: inline-block;
+  width: 18px;
+  height: 14px;
+  border-radius: 3px;
+  object-fit: cover;
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.15);
+}
+
 .lang-code{
   font-weight: 700;
   font-size: 12px;


### PR DESCRIPTION
Use image-based flags instead of emoji so SK/EN icons render reliably.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches language selector flags from emoji to CDN-hosted images for reliable display.
> 
> - Replace `span.lang-flag` emoji with `<img class="lang-flag-img" src="https://flagcdn.com/24x18/{sk|gb}.png">` in `public/index.html`
> - Add `.lang-flag-img` styles in `public/style.css` (size, border-radius, shadow); mobile header layout unaffected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee5efa1fb7a9e7f29a43269e66f86e1f6bad2152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->