### PR TITLE
fix: reposition language switch on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -6110,8 +6110,21 @@ header{
 @media (max-width: 768px){
   .header-right{
     gap: 8px;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    right: auto;
+    z-index: 3; /* above centered title */
   }
   .header-right .ai-watermark{
     display: none; /* to keep header compact on mobile */
+  }
+
+  .lang-btn{
+    padding: 5px 7px;
+    border-radius: 10px;
+  }
+  .lang-code{
+    font-size: 11px;
   }
 }


### PR DESCRIPTION
Move the SK/EN switch to top-left on small screens to avoid overlapping the centered header title.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Mobile header layout adjustment**
> 
> - Positions `header-right` absolutely at the top-left on screens ≤768px with higher `z-index` to avoid overlap with the centered title
> - Hides `ai-watermark` within `header-right` on mobile to keep the header compact
> - Tweaks `lang-btn` padding/border-radius and reduces `lang-code` font-size for tighter mobile styling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f38018321914f330c83cbefb95b3ae81a2159d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->