### PR TITLE
feat(premium): add VIP tips for today (scorers + totals)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -362,6 +362,21 @@
 
       </div>
 
+      <!-- ===============================
+           🔥 VIP TIPY NA DNES
+           =============================== -->
+      <section id="vip-tips" class="vip-tips">
+        <div class="vip-tips-head">
+          <h2 data-i18n="vipTips.title">🔥 VIP tipy na dnes</h2>
+          <p class="vip-tips-sub" data-i18n="vipTips.subtitle">
+            Autonómne tipy na strelcov a góly podľa ratingov a L10 štatistík.
+          </p>
+        </div>
+        <div id="vip-tips-body" class="vip-tips-grid">
+          <p class="nhl-muted" data-i18n="common.loading">Načítavam…</p>
+        </div>
+      </section>
+
       <!-- ===== SUMMARY ===== -->
       <div class="premium-summary">
         <span data-i18n="premium.totalProfit">Celkový profit</span>

--- a/public/style.css
+++ b/public/style.css
@@ -6128,3 +6128,133 @@ header{
     font-size: 11px;
   }
 }
+
+/* ===============================
+   VIP tips cards (Premium)
+   =============================== */
+.vip-tips{
+  margin: 18px 0 10px;
+  padding: 14px 14px 10px;
+  border: 1px solid rgba(0,255,255,0.18);
+  border-radius: 14px;
+  background: rgba(0,0,0,0.22);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+}
+
+.vip-tips-head{
+  margin-bottom: 10px;
+}
+
+.vip-tips-head h2{
+  margin: 0 0 6px;
+  font-size: 16px;
+  color: #00eaff;
+  letter-spacing: 0.3px;
+  text-transform: none;
+}
+
+.vip-tips-sub{
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255,255,255,0.68);
+}
+
+.vip-tips-grid{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.vip-tip-card{
+  border: 1px solid rgba(255,255,255,0.10);
+  background: rgba(255,255,255,0.03);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.vip-tip-card-title{
+  margin: 0 0 10px;
+  font-size: 14px;
+  color: #eaf9ff;
+  letter-spacing: 0.2px;
+}
+
+.vip-tip-row{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 10px;
+  border-radius: 10px;
+  background: rgba(0,0,0,0.20);
+  border: 1px solid rgba(255,255,255,0.08);
+  margin-bottom: 8px;
+}
+
+.vip-tip-left{
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.vip-tip-rank{
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 12px;
+  color: #06131c;
+  background: rgba(0,255,255,0.85);
+  flex: 0 0 auto;
+}
+
+.vip-tip-text{
+  min-width: 0;
+}
+
+.vip-tip-title{
+  font-size: 13px;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vip-tip-meta{
+  font-size: 12px;
+  color: rgba(255,255,255,0.65);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vip-tip-right{
+  text-align: right;
+  flex: 0 0 auto;
+}
+
+.vip-tip-badge{
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(0,255,255,0.12);
+  border: 1px solid rgba(0,255,255,0.35);
+  color: #9ff6ff;
+  font-weight: 800;
+  font-size: 12px;
+}
+
+.vip-tip-label{
+  margin-top: 4px;
+  font-size: 11px;
+  color: rgba(255,255,255,0.55);
+}
+
+@media (max-width: 768px){
+  .vip-tips-grid{
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Show 3 autonomous scorer picks from today's games and game total goals recommendations based on player ratings and L10 team stats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new Premium-only "VIP tips" feature powered by existing player ratings and last-10 team stats.
> 
> - New `renderVipTips` in `public/app.js` with helpers (`teamNick`, `findStandingByNick`, `estimateGameTotal`); uses `/api/home` and cached `LAST_STANDINGS` to compute picks
> - Persists standings via `LAST_STANDINGS` and sets it in `fetchMatches`; VIP flow now calls `renderVipTips()` after loading premium data
> - UI: Adds `#vip-tips` section to `public/index.html` inside premium content, with containers for scorer picks and totals
> - i18n: Adds SK/EN strings under `vipTips.*`
> - Styles: Adds `.vip-tips` cards and row styles in `public/style.css`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05944381bb1a32766bd253b7f32b8676d7e20dba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->